### PR TITLE
Remove WAScan tool from installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ Bug Bounty Hunting Tools is a script to install the most popular tools
 
 - [List of tools](#Categorized-the-list-of-tools)
 - [Installation](#installation)
-- [Docker Pull and Run Instructions](#instructions)
-
-
 
 
 ## Categorized the list of tools
@@ -37,8 +34,12 @@ Script for aliases/shell functions: [https://github.com/unethicalnoob/aliases](h
 
 
 ``` 
- git clone https://github.com/unethicalnoob/BBHTv2 
- cd BBHTv2
- chmod +x bbhtv2.1.sh
- ./bbhtv2.1.sh
- ```
+git clone https://github.com/unethicalnoob/BBHTv2 
+cd BBHTv2
+chmod +x bbhtv2.1.sh
+./bbhtv2.1.sh
+```
+### One Liner Install
+```
+curl https://raw.githubusercontent.com/unethicalnoob/BBHTv2/master/bbhtv2.sh | sudo bash 
+```

--- a/bbhtv2.sh
+++ b/bbhtv2.sh
@@ -484,10 +484,6 @@ chmod +x install
 echo "${BLUE} done${RESET}"
 echo ""
 
-echo "${BLUE} WAScan${RESET}"
-git clone https://github.com/m4ll0k/WAScan.git ~/tools/Frameworks/WAScan
-echo "${BLUE} done${RESET}"
-echo ""
 
 #install Blackwidow#
 echo "${BLUE} blackwidow${RESET}"


### PR DESCRIPTION
Remove WAScan tool from installation because it is no longer available 

- When the install script is running the cli asks user for GitHub username and password to find that repo but it is not available so the installation stuck until user will press enter to skip
- so it is better to remove this tool



https://github.com/m4ll0k/WAScan.git
![image](https://user-images.githubusercontent.com/57517785/200171068-47c0ea47-aff1-4f4e-bb1a-fbf37db55800.png)

![image](https://user-images.githubusercontent.com/57517785/200171031-cd43a10c-8a2e-4c14-af9b-d1dd8842a180.png)
